### PR TITLE
Added throws for more unsupported functions

### DIFF
--- a/src/mockReactRedux.ts
+++ b/src/mockReactRedux.ts
@@ -10,6 +10,12 @@ type MockSituation = {
 
 let mockSituation: MockSituation | undefined;
 
+const mockSupportedError = (name: string) => {
+  throw new Error(
+    `${name} is not yet supported when using mock-react-redux. Consider filing an issue on https://github.com/Codecademy/mock-react-redux. Thanks, friend!`,
+  );
+};
+
 const mockStateError = (name: string) => {
   throw new Error(
     `You imported mock-react-redux but didn't call mockReactRedux() before calling ${name} from react-redux.`,
@@ -40,11 +46,21 @@ jest.mock("react-redux", () => {
 
       return mockSituation.state;
     }),
-    Provider: () => {
-      throw new Error(`Provider is not supported when using mock-react-redux.`);
-    },
     useDispatch: getDispatch,
     useSelector: getSelector,
+    ...[
+      "batch",
+      "connectAdvanced",
+      "createDispatchHook",
+      "createSelectorHook",
+      "createStoreHook",
+      "Provider",
+      "shallowEqual",
+      "useStore",
+    ].reduce<Record<string, () => void>>((accum, apiName) => {
+      accum[apiName] = () => mockSupportedError(apiName);
+      return accum;
+    }, {}),
   };
 });
 

--- a/src/tests/Provider.test.tsx
+++ b/src/tests/Provider.test.tsx
@@ -1,8 +1,0 @@
-import "mock-react-redux";
-import { Provider } from "react-redux";
-
-describe("Provider", () => {
-  it("throws an error when mock-react-redux has been imported", async () => {
-    expect(Provider).toThrowError("Provider is not supported when using mock-react-redux.");
-  });
-});

--- a/src/tests/unsupported.test.tsx
+++ b/src/tests/unsupported.test.tsx
@@ -1,0 +1,24 @@
+import "mock-react-redux";
+import * as ReactRedux from "react-redux";
+
+const apiNames = [
+    "batch",
+    "connectAdvanced",
+    "createDispatchHook",
+    "createSelectorHook",
+    "createStoreHook",
+    "Provider",
+    "shallowEqual",
+    "useStore",
+  ] as const;
+
+describe("Unsupported APIs", () => {
+  describe.each(apiNames)("%s", (apiName) => {
+    it("throws an error when mock-react-redux has been imported", async () => {
+      expect(ReactRedux[apiName]).toThrowError(
+        `${apiName} is not yet supported when using mock-react-redux. Consider filing an issue on https://github.com/Codecademy/mock-react-redux. Thanks, friend!`,
+      );
+    });
+  });
+});
+


### PR DESCRIPTION
See API docs such as:

* https://react-redux.js.org/api#connectadvanced
* https://react-redux.js.org/api/batch

I checked for all the `export function`s in the DefinitelyTyped definitions for `react-redux`.

Fixes #12.