### PR TITLE
Adding default export support for mockReactRedux 🎉

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
-export * from "./mockReactRedux";
+import { mockReactRedux } from "./mockReactRedux";
+
 export * from "./types";
+
+export { mockReactRedux };
+
+export default mockReactRedux;


### PR DESCRIPTION
This PR attempts to solve issue #13 by adding default support for mockReactRedux. 

I tested the default imports in the test files by importing `mockReactRedux` locally from `index.ts` and all the tests were passing. ✅ 

```ts
import mockReactRedux from "../index";
```